### PR TITLE
feat: add workflow trigger for ai:implement label

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -1,0 +1,34 @@
+name: Agent Implement
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  implement:
+    if: github.event.label.name == 'ai:implement'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Swap labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+
+            // Remove ai:implement label
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              name: 'ai:implement'
+            });
+
+            // Add ai:in-progress label
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: ['ai:in-progress']
+            });


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow that triggers when `ai:implement` label is added to an issue
- Automatically swaps labels: removes `ai:implement`, adds `ai:in-progress`

Closes #001-001