### PR TITLE
fix: add issues write permission to workflow

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  issues: write
+
 jobs:
   implement:
     if: github.event.label.name == 'ai:implement'


### PR DESCRIPTION
## Summary

- Add `permissions: issues: write` to workflow so GITHUB_TOKEN can modify labels