### PR TITLE
feat: add branch creation from issue

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  contents: write
 
 jobs:
   implement:
@@ -35,3 +36,20 @@ jobs:
               issue_number: issue.number,
               labels: ['ai:in-progress']
             });
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create and push branch
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          # Generate slug: lowercase, remove special chars, take first 5 words, join with hyphens
+          SLUG=$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 ]//g' | awk '{for(i=1;i<=5&&i<=NF;i++) printf "%s%s", $i, (i<5&&i<NF?"-":"")}')
+          BRANCH_NAME="agent/issue-${ISSUE_NUMBER}-${SLUG}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH_NAME"
+          git push origin "$BRANCH_NAME"

--- a/tickets/001-002-branch-creation.md
+++ b/tickets/001-002-branch-creation.md
@@ -26,3 +26,14 @@ Extend the workflow to check out the repository and create a properly named bran
 ## Dependencies
 
 - 001-001 (workflow trigger)
+
+## Implementation Notes
+
+Extended `.github/workflows/agent-implement.yml` with:
+- Added `contents: write` permission to allow pushing branches
+- Added `actions/checkout@v4` step to check out the repository
+- Added "Create and push branch" step that:
+  - Generates slug from issue title: lowercase, remove special chars, take first 5 words, join with hyphens
+  - Creates branch named `agent/issue-{number}-{slug}`
+  - Configures git user as github-actions[bot]
+  - Pushes the branch to origin


### PR DESCRIPTION
## Summary

- Extends the workflow to check out the repository and create a properly named branch based on the issue
- Adds `contents: write` permission to allow pushing branches
- Generates slug from issue title: lowercase, remove special chars, take first 5 words, join with hyphens
- Creates branch named `agent/issue-{number}-{slug}` and pushes to origin

Implements ticket 001-002.