### PR TITLE
fix: include working directory in agent prompt

### DIFF
--- a/src/claude-runner.mjs
+++ b/src/claude-runner.mjs
@@ -2,12 +2,14 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 
 export const FILE_EDITING_TOOLS = ["Read", "Edit", "Write", "Glob", "Grep"];
 
-export function buildPrompt(title, body) {
+export function buildPrompt(title, body, cwd = process.cwd()) {
   if (!title || !body) {
     throw new Error("Title and body are required");
   }
 
   const systemInstructions = `You are a code editing agent. Your task is to make changes to the codebase.
+
+Working directory: ${cwd}
 
 IMPORTANT: You MUST use the file editing tools (Read, Edit, Write, Glob, Grep) to complete your task.
 - Use Glob to find files by pattern
@@ -15,6 +17,9 @@ IMPORTANT: You MUST use the file editing tools (Read, Edit, Write, Glob, Grep) t
 - Use Read to read file contents
 - Use Edit to modify existing files
 - Use Write to create new files
+
+All file paths must be absolute paths within the working directory.
+For example, to create a file called "hello.txt" in the root, use: ${cwd}/hello.txt
 
 Do NOT just describe what changes should be made - actually make them using the tools.`;
 

--- a/tests/claude-runner.test.mjs
+++ b/tests/claude-runner.test.mjs
@@ -8,16 +8,22 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 
 describe("buildPrompt", () => {
   it("includes system instructions and title/body", () => {
-    const result = buildPrompt("My Title", "Some body text");
+    const result = buildPrompt("My Title", "Some body text", "/test/dir");
     expect(result).toContain("# My Title");
     expect(result).toContain("Some body text");
     expect(result).toContain("You are a code editing agent");
     expect(result).toContain("MUST use the file editing tools");
   });
 
+  it("includes working directory in prompt", () => {
+    const result = buildPrompt("Title", "Body", "/my/working/dir");
+    expect(result).toContain("Working directory: /my/working/dir");
+    expect(result).toContain("/my/working/dir/hello.txt");
+  });
+
   it("handles multiline body", () => {
     const body = "Line 1\nLine 2\nLine 3";
-    const result = buildPrompt("Title", body);
+    const result = buildPrompt("Title", body, "/test");
     expect(result).toContain("# Title");
     expect(result).toContain("Line 1\nLine 2\nLine 3");
   });

--- a/tickets/006-ci-caching.md
+++ b/tickets/006-ci-caching.md
@@ -1,0 +1,39 @@
+# Ticket 006: CI Caching for Faster Workflows
+
+## Summary
+
+Optimise CI workflow performance by caching Node.js dependencies and environment setup.
+
+## Acceptance Criteria
+
+- [ ] Cache `node_modules` between workflow runs
+- [ ] Cache npm global packages if needed
+- [ ] Use `actions/setup-node` built-in caching
+- [ ] Workflow should skip `npm install` when cache hit
+- [ ] Document cache invalidation strategy
+
+## Technical Notes
+
+```yaml
+- name: Setup Node.js
+  uses: actions/setup-node@v4
+  with:
+    node-version-file: '.nvmrc'
+    cache: 'npm'
+```
+
+The `cache: 'npm'` option will automatically cache based on `package-lock.json`. Since we're ignoring `package-lock.json`, we may need to use a custom cache key based on `package.json` hash instead:
+
+```yaml
+- name: Cache node_modules
+  uses: actions/cache@v4
+  with:
+    path: node_modules
+    key: ${{ runner.os }}-node-${{ hashFiles('package.json') }}
+    restore-keys: |
+      ${{ runner.os }}-node-
+```
+
+## Dependencies
+
+- 001-003-A (Agent SDK script)


### PR DESCRIPTION
## Summary

- Agent was writing to `/root` instead of the repo directory
- Now includes `cwd` in system prompt with example path
- Added ticket 006 for CI caching

Fixes issue where agent didn't know where to create files.