### PR TITLE
fix: include Closes #N in PR descriptions

### DIFF
--- a/.github/scripts/generate_pr_description.py
+++ b/.github/scripts/generate_pr_description.py
@@ -14,6 +14,7 @@ from claude_runner import build_pr_description_prompt, run_claude
 async def main():
     issue_title = os.environ.get("ISSUE_TITLE")
     issue_body = os.environ.get("ISSUE_BODY")
+    issue_number = os.environ.get("ISSUE_NUMBER")
     diff = os.environ.get("GIT_DIFF", "")
     api_key = os.environ.get("ANTHROPIC_API_KEY")
 
@@ -21,13 +22,13 @@ async def main():
         print("Error: ANTHROPIC_API_KEY environment variable is required", file=sys.stderr)
         sys.exit(1)
 
-    if not issue_title or not issue_body:
-        print("Error: ISSUE_TITLE and ISSUE_BODY environment variables are required", file=sys.stderr)
+    if not issue_title or not issue_body or not issue_number:
+        print("Error: ISSUE_TITLE, ISSUE_BODY and ISSUE_NUMBER environment variables are required", file=sys.stderr)
         sys.exit(1)
 
     try:
         cwd = os.getcwd()
-        prompt = build_pr_description_prompt(issue_title, issue_body, diff, cwd)
+        prompt = build_pr_description_prompt(issue_title, issue_body, diff, int(issue_number), cwd)
 
         # Use fewer turns for this simpler task
         async for message in run_claude(prompt, cwd, max_turns=3):

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -123,7 +123,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
-          GIT_DIFF: ${{ steps.changes.outputs.has_changes == 'true' && '' || '' }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           export GIT_DIFF="$(git diff HEAD~1)"
           uv run python .github/scripts/generate_pr_description.py

--- a/src/claude_runner.py
+++ b/src/claude_runner.py
@@ -36,7 +36,7 @@ Do NOT just describe what changes should be made - actually make them using the 
     return f"{system_instructions}\n\n# {title}\n\n{body}"
 
 
-def build_pr_description_prompt(title: str, body: str, diff: str, cwd: str | None = None) -> str:
+def build_pr_description_prompt(title: str, body: str, diff: str, issue_number: int, cwd: str | None = None) -> str:
     """Build prompt for generating PR description."""
     if cwd is None:
         cwd = os.getcwd()
@@ -48,8 +48,8 @@ Working directory: {cwd}
 Write the PR description to: {cwd}/.pr-description.md
 
 The description should:
-1. Have a "## Summary" section with 2-3 bullet points describing what was done
-2. Reference the original issue requirements
+1. Start with "Closes #{issue_number}" on its own line
+2. Have a "## Summary" section with 2-3 bullet points describing what was done
 3. Be concise and factual
 
 Do NOT include a test plan section.

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -52,15 +52,16 @@ def test_build_prompt_raises_when_body_missing():
 # build_pr_description_prompt tests
 
 def test_build_pr_description_prompt_includes_issue_and_diff():
-    result = build_pr_description_prompt("Fix bug", "Fix the login bug", "+added line", "/test/dir")
+    result = build_pr_description_prompt("Fix bug", "Fix the login bug", "+added line", 123, "/test/dir")
     assert "Fix bug" in result
     assert "Fix the login bug" in result
     assert "+added line" in result
     assert ".pr-description.md" in result
+    assert "Closes #123" in result
 
 
 def test_build_pr_description_prompt_includes_working_directory():
-    result = build_pr_description_prompt("Title", "Body", "diff", "/my/dir")
+    result = build_pr_description_prompt("Title", "Body", "diff", 456, "/my/dir")
     assert "/my/dir/.pr-description.md" in result
 
 


### PR DESCRIPTION
Ensures the generated PR description includes `Closes #N` to auto-close the issue when merged.