### PR TITLE
fix: use PAT_TOKEN for PR creation to trigger CI

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Create pull request
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |


### PR DESCRIPTION
## Summary

- Changed `GH_TOKEN` from `GITHUB_TOKEN` to `PAT_TOKEN` when creating PRs in the agent-implement workflow

This fixes the issue where CI tests weren't running on PRs created by the agent. When PRs are created using `GITHUB_TOKEN`, GitHub intentionally does not trigger other workflows (to prevent infinite loops). Using `PAT_TOKEN` allows the `pull_request` event to trigger the CI workflow.