### PR TITLE
I want to be able to puely have a title in the issue for the bot to work?

### DIFF
--- a/.github/scripts/generate_pr_description.py
+++ b/.github/scripts/generate_pr_description.py
@@ -22,9 +22,13 @@ async def main():
         print("Error: ANTHROPIC_API_KEY environment variable is required", file=sys.stderr)
         sys.exit(1)
 
-    if not issue_title or not issue_body or not issue_number:
-        print("Error: ISSUE_TITLE, ISSUE_BODY and ISSUE_NUMBER environment variables are required", file=sys.stderr)
+    if not issue_title or not issue_number:
+        print("Error: ISSUE_TITLE and ISSUE_NUMBER environment variables are required", file=sys.stderr)
         sys.exit(1)
+
+    # Allow empty body - title alone is sufficient
+    if issue_body is None:
+        issue_body = ""
 
     try:
         cwd = os.getcwd()

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -49,19 +49,23 @@ def test_build_prompt_handles_multiline_body():
 
 
 def test_build_prompt_raises_when_title_missing():
-    with pytest.raises(ValueError, match="Title and body are required"):
+    with pytest.raises(ValueError, match="Title is required"):
         build_prompt("", "body")
 
-    with pytest.raises(ValueError, match="Title and body are required"):
+    with pytest.raises(ValueError, match="Title is required"):
         build_prompt(None, "body")
 
 
-def test_build_prompt_raises_when_body_missing():
-    with pytest.raises(ValueError, match="Title and body are required"):
-        build_prompt("title", "")
+def test_build_prompt_allows_empty_body():
+    """Test that body is optional - title alone is sufficient."""
+    # Empty string body should work
+    result = build_prompt("title", "")
+    assert "# title" in result
+    assert not result.endswith("\n\n")  # No extra content after title
 
-    with pytest.raises(ValueError, match="Title and body are required"):
-        build_prompt("title", None)
+    # None body should work (converted to empty string)
+    result = build_prompt("title", None)
+    assert "# title" in result
 
 
 # build_pr_description_prompt tests


### PR DESCRIPTION
Closes #69

## Summary

- Made issue body optional throughout the codebase, allowing the bot to work with only an issue title
- Updated validation logic in `generate_pr_description.py` and `claude_runner.py` to only require title, treating empty/None body as valid
- Modified prompt building functions to handle empty bodies gracefully and updated tests to reflect the new behavior