### PR TITLE
fix: support bare ai:plan/ai:implement in titles and add chunked planning

### DIFF
--- a/.github/scripts/run_claude_plan.py
+++ b/.github/scripts/run_claude_plan.py
@@ -9,7 +9,7 @@ import sys
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
-from claude_runner import run_claude_plan
+from claude_runner import run_claude_plan_chunked
 
 
 async def main():
@@ -32,8 +32,8 @@ async def main():
     try:
         cwd = os.getcwd()
 
-        # Run plan generation with limited turns (planning should be quick)
-        async for message in run_claude_plan(issue_title, issue_body, cwd):
+        # Run plan generation in chunks (10 turns per chunk, up to 3 chunks = 30 turns max)
+        async for message in run_claude_plan_chunked(issue_title, issue_body, cwd):
             print(json.dumps(message, default=str))
 
     except Exception as e:

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -15,7 +15,8 @@ jobs:
       github.event.issue.author_association == 'OWNER' &&
       (github.event.label.name == 'ai:implement' ||
        contains(github.event.issue.title, '[ai:implement]') ||
-       contains(github.event.issue.title, '@ai-implement'))
+       contains(github.event.issue.title, '@ai-implement') ||
+       contains(github.event.issue.title, 'ai:implement'))
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +24,8 @@ jobs:
         if: >-
           !contains(github.event.issue.labels.*.name, 'ai:implement') &&
           (contains(github.event.issue.title, '[ai:implement]') ||
-           contains(github.event.issue.title, '@ai-implement'))
+           contains(github.event.issue.title, '@ai-implement') ||
+           contains(github.event.issue.title, 'ai:implement'))
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/agent-plan.yml
+++ b/.github/workflows/agent-plan.yml
@@ -14,7 +14,8 @@ jobs:
       github.event.issue.author_association == 'OWNER' &&
       (github.event.label.name == 'ai:plan' ||
        contains(github.event.issue.title, '[ai:plan]') ||
-       contains(github.event.issue.title, '@ai-plan'))
+       contains(github.event.issue.title, '@ai-plan') ||
+       contains(github.event.issue.title, 'ai:plan'))
     runs-on: ubuntu-latest
 
     steps:
@@ -22,7 +23,8 @@ jobs:
         if: >-
           !contains(github.event.issue.labels.*.name, 'ai:plan') &&
           (contains(github.event.issue.title, '[ai:plan]') ||
-           contains(github.event.issue.title, '@ai-plan'))
+           contains(github.event.issue.title, '@ai-plan') ||
+           contains(github.event.issue.title, 'ai:plan'))
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Generate an implementation plan before executing changes:
 - `[ai:plan] Add user authentication`
 - `Fix login bug @ai-plan`
 - `@ai-plan Implement dark mode feature`
+- `ai:plan Add new feature`
 
 **Plan workflow:**
 1. Swaps labels (`ai:plan` → `ai:planning` → `ai:planned`)
@@ -35,6 +36,7 @@ Add the `ai:implement` label to an issue (or include `[ai:implement]` or `@ai-im
 - `[ai:implement] Add user authentication`
 - `Fix login bug @ai-implement`
 - `@ai-implement Implement dark mode feature`
+- `ai:implement Add new feature`
 
 **Implementation workflow:**
 1. Swaps labels (`ai:implement` → `ai:in-progress`)


### PR DESCRIPTION
## Summary

- Added `ai:plan` and `ai:implement` (without brackets or @ prefix) as valid title triggers - previously only `[ai:plan]` and `@ai-plan` worked
- Added `run_claude_plan_chunked` function that gives the planning agent continuation support (10 turns per chunk, up to 3 chunks = 30 turns max)
- The planning workflow now uses the same chunked execution pattern as implementation, so it won't fail on complex issues that need more exploration
- Added comprehensive tests for the new planning functions

Fixes #73