### PR TITLE
fix: use PAT_TOKEN in comment handler to trigger implement workflow

### DIFF
--- a/.github/workflows/comment-handler.yml
+++ b/.github/workflows/comment-handler.yml
@@ -57,7 +57,7 @@ jobs:
         if: steps.check-label.outputs.result == 'has-plan'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT_TOKEN }}
           script: |
             const issue = context.payload.issue;
 
@@ -70,6 +70,7 @@ jobs:
             }).catch(() => {});
 
             // Add ai:implement label to trigger the implement workflow
+            // Note: Using PAT_TOKEN instead of GITHUB_TOKEN so this triggers the workflow
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary

- Changed comment-handler.yml to use `PAT_TOKEN` instead of `GITHUB_TOKEN` when adding the `ai:implement` label
- This fixes the issue where `/apply` comments set the label but don't trigger the implement workflow

The default `GITHUB_TOKEN` actions don't trigger other workflows (to prevent infinite loops). Using `PAT_TOKEN` ensures the implement workflow actually runs.

Fixes the issue reported with #75 where `/apply` was acknowledged but no implementation started.