### PR TITLE
@ai-plan

### DIFF
--- a/.plan-context.md
+++ b/.plan-context.md
@@ -1,0 +1,128 @@
+# Implementation Plan: Agent Progress Summaries
+
+## Overview
+
+Add on-the-fly progress summaries for the agent during chunked execution. At the end of each chunk (after a set of turns), generate a summary of what was accomplished and what remains to be done, then post it as a GitHub issue comment. When the completion marker is emitted, generate and post a final comprehensive summary of all work completed.
+
+## Key Concepts
+
+- **Chunk**: A set of turns (default: 10 turns per chunk, up to 5 chunks = 50 turns max)
+- **Progress Summary**: Generated after each chunk ends (unless it's the final chunk with completion marker)
+- **Final Summary**: Generated when the completion marker (`.claude-complete`) is created by the agent
+- **Message Stream**: The `run_claude_chunked` function yields messages from the Claude Agent SDK during execution
+
+## Files to Modify/Create
+
+### Files to Modify
+
+1. **`/home/runner/work/mobile-agents/mobile-agents/src/claude_runner.py`**
+   - Add function to build summary prompt
+   - Add function to generate summaries using Claude
+   - Add function to collect messages from a chunk for summarization
+   - Modify `run_claude_chunked` to track chunk messages and trigger summaries
+
+2. **`/home/runner/work/mobile-agents/mobile-agents/.github/scripts/run_claude.py`**
+   - Add GitHub API integration to post comments to issues
+   - Add logic to collect chunk messages and trigger summary generation
+   - Add logic to detect completion and trigger final summary
+   - Pass issue number from environment variables
+
+3. **`/home/runner/work/mobile-agents/mobile-agents/.github/workflows/agent-implement.yml`**
+   - Pass `ISSUE_NUMBER` environment variable to the `run_claude.py` script
+   - Pass `GITHUB_TOKEN` for GitHub API access
+
+### Files to Create
+
+4. **`/home/runner/work/mobile-agents/mobile-agents/tests/test_summaries.py`** (optional)
+   - Tests for summary generation functions
+   - Tests for message collection and formatting
+
+## Implementation Steps
+
+### Step 1: Add Summary Generation to `claude_runner.py`
+
+**1.1** Add a function to build a summary prompt:
+```python
+def build_summary_prompt(messages: list, chunk_number: int, is_final: bool = False) -> str
+```
+- Takes a list of messages from a chunk
+- Formats them into a prompt asking Claude to summarize
+- If `is_final=True`, asks for comprehensive summary of all work
+- If `is_final=False`, asks for progress summary (what's done, what's left)
+
+**1.2** Add a function to generate summaries:
+```python
+async def generate_summary(messages: list, chunk_number: int, is_final: bool = False, cwd: str | None = None) -> str
+```
+- Builds summary prompt using messages
+- Calls Claude with a simple query (not using file editing tools)
+- Returns the summary text
+- Uses a smaller model/fewer turns for efficiency (e.g., max_turns=3)
+
+**1.3** Add message collection helper:
+```python
+def format_messages_for_summary(messages: list) -> str
+```
+- Formats message objects into readable text for the summary prompt
+- Extracts relevant content from different message types
+- Filters out system messages that aren't relevant to summarization
+
+### Step 2: Modify `run_claude_chunked` to Support Summaries
+
+**2.1** Update function signature to accept callback for summaries:
+```python
+async def run_claude_chunked(
+    title: str,
+    body: str,
+    cwd: str | None = None,
+    turns_per_chunk: int = DEFAULT_TURNS_PER_CHUNK,
+    max_chunks: int = DEFAULT_MAX_CHUNKS,
+    on_chunk_complete: callable | None = None,  # NEW
+    on_final_complete: callable | None = None,  # NEW
+)
+```
+
+**2.2** Collect messages per chunk:
+- Track all messages yielded during each chunk iteration
+- Store them in a list for the current chunk
+
+**2.3** Trigger callbacks:
+- After each chunk completes (before checking completion marker), call `on_chunk_complete(chunk_messages, chunk_num)` if provided
+- When completion marker is detected, call `on_final_complete(all_messages)` if provided before returning
+
+**Alternative Approach** (simpler): Instead of callbacks, modify `run_claude_chunked` to yield a special "chunk_complete" message that includes the messages from that chunk. The caller can detect this and handle summaries.
+
+### Step 3: Update GitHub Integration in `run_claude.py`
+
+**3.1** Add GitHub API helper functions:
+```python
+def post_issue_comment(issue_number: int, body: str, token: str, repo: str)
+```
+- Uses GitHub REST API to post comments
+- Handles authentication with provided token
+- Formats comment with appropriate markdown
+
+**3.2** Add summary orchestration:
+```python
+async def run_with_summaries(title: str, body: str, issue_number: int, cwd: str)
+```
+- Collects messages as they stream from `run_claude_chunked`
+- Groups messages by chunk
+- At end of each chunk, calls `generate_summary()` and posts to issue
+- On final completion, generates final summary and posts to issue
+
+**3.3** Update main function:
+- Get `ISSUE_NUMBER` from environment
+- Get `GITHUB_TOKEN` from environment
+- Get repository info from environment (or derive from GitHub Actions context)
+- Call `run_with_summaries()` instead of directly calling `run_claude_chunked()`
+
+**3.4** Format progress comments:
+```markdown
+## 🔄 Progress Update - Chunk {N}
+
+### What was done:
+- [bullet points]
+
+### What's remaining:
+- [bullet points]


### PR DESCRIPTION
Closes #78

## Summary

- Added implementation plan for agent progress summaries feature
- Plan defines architecture for generating and posting summaries to GitHub issues after each chunk of agent turns
- Includes detailed steps for modifying `claude_runner.py`, `run_claude.py`, and the GitHub workflow to support on-the-fly progress tracking and final completion summaries