### PR TITLE
add dspy as a dependecy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "GitHub issue to PR automation with Claude"
 requires-python = ">=3.12"
 dependencies = [
     "claude-agent-sdk>=0.1.18",
+    "dspy==3.0.4",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Closes #88

## Summary

- Added dspy version 3.0.4 as a project dependency
- Updated pyproject.toml to include dspy in the dependencies list